### PR TITLE
Add support for custom component file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,22 @@ Initialize warp-reactor in your react project.
 
 |  option  |  action   |
 |----------|----------|
-|\-\-styles | Defines the file extension for the style file to be imported by the component: `warp-reactor init --styles scss`|
-|\-\-path   | Defines the root directory of your components: `warp-reactor init --path src`|
+|&#8209;&#8209;styles | Defines the file extension for the style file to be imported by the component: `warp-reactor init --styles scss`|
+|&#8209;&#8209;path   | Defines the root directory of your components: `warp-reactor init --path src`|
 
+### Generating Components
 Now you can begin generating components.
 
 `warp-reactor generate component [component-name]`
 
-Examples: 
+|  option  |  shorthand | action   |
+|----------|----------|----------|
+|&#8209;&#8209;extension | &#8209;e | Defines the file extension for the component file |
+|&#8209;&#8209;styles | &#8209;s  | Specifies the style type and overrides the style attribute specified in reactor.json file |
+| &#8209;&#8209;path | &#8209;p | Specifies the sub directory in which to generate. Appends to the end of the path specified in reactor.json |
+| &#8209;&#8209;no&#8209;dir | | If set, the files will be generated without a parent directory |
+
+##### Examples: 
 `warp-reactor generate component test-component`
 Running the `generate` command with a path for the name generates a new component at the specified path with the name of the last path element.
 
@@ -30,7 +38,7 @@ Running the `generate` command with a path for the name generates a new componen
 warp-reactor init --styles scss --path src
 warp-reactor generate component test-directory/test-component
 ```
-Generates test-component.js and test-component.scss to src/test-directory/test-component.
+Generates _test-component.js_ and _test-component.scss_ to the *src/test-directory/test-component* directory.
 
 If you would like a component to not be generated in it's own directory, generate it with the `--no-dir` flag
 

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ program
     .description('Creates a reactor.json file in the current directory')
     .option('-s, --styles [styles]', 'When used with the \'init\' command, specifies the extension of style files, IE \'scss\'')
     .option('-p, --path [path]', 'When used with the \'init\' command, specfies the path to which all generate commands will write. You can append to this path later (with the --path option on the \'generate\' command, so it\'s wise set the path here to the root directory')
+    .option('-e, --extension [extension]', 'Specifies the extension for component files')
     .action((cmd) => {
-        fs.writeFileSync('reactor.json', `{\n    "path": "${cmd.path ? './' + cmd.path : './'}",\n    "styles": "${cmd.styles ? cmd.styles : 'css'}"\n}`, 'utf-8', (err) => {
+        fs.writeFileSync('reactor.json', `{\n    "extension": "${cmd.extension ? cmd.extension : 'js'}",\n    "path": "${cmd.path ? './' + cmd.path : './'}",\n    "styles": "${cmd.styles ? cmd.styles : 'css'}"\n}`, 'utf-8', (err) => {
             if (err) {
                 console.log('Error creating reactor.json!');
             }
@@ -27,6 +28,7 @@ program
     program
     .command('generate <type> <name>')
     .description('Generates a react [component] into the specified directory')
+    .option('-e, --extension [extension]', 'Specifies an extension to be used in favor of the default listed in reactor.json')
     .option('-s, --styles [styles]', 'When used with the \'generate\' command, specifies the style type and overrides the style attribute specified in reactor.json file')
     .option('-p, --path [path]', 'When used with the \'generate\' command, specifies the sub directory in which to generate. Appends to the end of the path specified in reactor.json')
     .option('--no-dir', 'If set, the files will be generated without a parent directory')
@@ -38,7 +40,7 @@ program
 
         if (type === 'component') {
             let p = cmd.path ? config.path + '/' + cmd.path : config.path;
-            generateComponent(name, cmd.styles, p, !cmd.dir);
+            generateComponent(name, cmd.styles, p, !cmd.dir, cmd.extension);
         } else {
             console.log('Type ' + type + ' is not a valid type!');
             return;
@@ -47,7 +49,7 @@ program
 
 program.parse(process.argv)
 
-function generateComponent(name, styles = config.styles, path = config.path, nodir=false) {
+function generateComponent(name, styles = config.styles, path = config.path, nodir=false, extension = config.extension) {
     if (!config) {
         console.log('You must run warp-reactor init first!');
         return;
@@ -61,7 +63,7 @@ function generateComponent(name, styles = config.styles, path = config.path, nod
     makeFile(name, styles, path, '', nodir);
 
     // now generate a react component
-    makeFile(name, 'js', path, `import React, { Component } from 'react';\nimport './${name + '.' + styles}';\n\nexport default class ${componentName} extends Component {\n    render() {\n        return;\n    }\n}`, nodir);
+    makeFile(name, extension, path, `import React, { Component } from 'react';\nimport './${name + '.' + styles}';\n\nexport default class ${componentName} extends Component {\n    render() {\n        return;\n    }\n}`, nodir);
 }
 
 function makeFile(name, extension, path = config.path, content = '', nodir = false) {


### PR DESCRIPTION
This PR adds support for custom file extensions for the component file. Extensions can be set during initialization, in the config file, or by using the `-e` flag when generating a new component.